### PR TITLE
restore original sigaction in restoreSignalHandler

### DIFF
--- a/src/crashhandler_unix.cpp
+++ b/src/crashhandler_unix.cpp
@@ -67,7 +67,7 @@ namespace {
       if (sigaction(signal_number, &(old_action_it->second), nullptr) < 0) {
          std::string signal_name;
          auto signal_name_it = gSignals.find(signal_number);
-         if (signal_name_it == gSignals.end()) {
+         if (signal_name_it != gSignals.end()) {
             signal_name = signal_name_it->second;
          } else {
             signal_name = std::to_string(signal_number);


### PR DESCRIPTION
- Save original sigactions in a map called gSavedSigActions
- In restoreSignalHandler, do nothing if there is no saved sigaction.
  If there is a saved sigaction, then re-install it.
- Fixes issue #253 in upstream.
